### PR TITLE
Add a simple wrapper script

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -36,4 +36,7 @@ in with pkgs; rec {
  hie80 = jse hie80Pkgs.haskell-ide-engine;
  hie82 = jse (import ./ghc-8.2.nix { inherit pkgs; }).haskell-ide-engine;
  hie84 = jse hie84Pkgs.haskell-ide-engine;
+ wrapper = import ./wrapper.nix {
+   inherit (pkgs) lib writeScriptBin; inherit hie80 hie82 hie84;
+ };
 }

--- a/wrapper.nix
+++ b/wrapper.nix
@@ -1,0 +1,29 @@
+{ lib, writeScriptBin
+, hie80, hie82, hie84
+}:
+
+writeScriptBin "hie" ''
+#!/usr/bin/env bash
+
+GHCBIN='ghc'
+if type -f stack >/dev/null; then
+  # Prefer stack, if available
+  GHCBIN='stack ghc --'
+fi
+
+versionNumber=$($GHCBIN --version)
+HIEBIN='hie'
+case $versionNumber in
+  *8.0*)
+      HIEBIN='${lib.getBin hie80}/bin/hie'
+      ;;
+  *8.2*)
+      HIEBIN='${lib.getBin hie82}/bin/hie'
+      ;;
+  *8.4*)
+      HIEBIN='${lib.getBin hie84}/bin/hie'
+      ;;
+esac
+
+$HIEBIN $@
+''


### PR DESCRIPTION
The simple wrapper script will automatically select the correct
haskell-ide-engine version for the current version of GHC. The GHC version is
detected using stack if available; otherwise, the default GHC is used.